### PR TITLE
WIP: Try to build wit han older version of libvips

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - cffi >=1.0
-    - libvips 8.9
+    - libvips 8.11
     - pip
     - pkgconfig         # [not win]
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - cffi >=1.0
-    - libvips 8.10
+    - libvips 8.9
     - pip
     - pkgconfig         # [not win]
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - cffi >=1.0
-    - libvips 8.11
+    - libvips 8.10
     - pip
     - pkgconfig         # [not win]
     - pytest
@@ -45,8 +45,10 @@ requirements:
     - python
 
 test:
-  imports:
-    - pyvips
+  # imports:
+  #   - pyvips
+  commands:
+    - python -c "import logging;logging.basicConfig(level=logging.DEBUG);import pyvips"
 
 about:
   home: https://github.com/libvips/pyvips

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
   sha256: 24f71106de2000153ca3654f5815c620c239bc6e980b72484ae5e121ecbe4f5a
 
 build:
-  number: 1
+  number: 2
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
   skip: true  # [win]
 
@@ -34,7 +34,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - cffi >=1.0
-    - libvips >=8.12
+    - libvips 8.10
     - pip
     - pkgconfig         # [not win]
     - pytest


### PR DESCRIPTION
Rebuilding:
https://github.com/conda-forge/pyvips-feedstock/pull/12#issuecomment-975486957

- 8.9 unsolvable
- 8.10 Failed
- 8.11 working

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
